### PR TITLE
NEW: choose appropriate protocol, based on current site protocol

### DIFF
--- a/code/RecaptchaProtector.php
+++ b/code/RecaptchaProtector.php
@@ -14,7 +14,9 @@ class RecaptchaProtector implements SpamProtector {
 	 * @return string
 	 */
 	function getFormField($name = "RecaptchaField", $title = "Captcha", $value = null, $form = null, $rightTitle = null) {
-		return new RecaptchaField($name, $title, $value, $form, $rightTitle);
+		$field = new RecaptchaField($name, $title, $value, $form, $rightTitle);
+		$field->useSSL = Director::protocol() == 'https://';
+		return $field;
 	}
 	
 	/**


### PR DESCRIPTION
Automatically choose HTTPS, if the site is currently using that protocol. This resolves issues with chrome/ie not displaying the recaptcha field when site is using HTTPS.

Note: branch is from a few commits back.
