### PR TITLE
Update RecaptchaField.php, invalid-request-cookie error

### DIFF
--- a/code/RecaptchaField.php
+++ b/code/RecaptchaField.php
@@ -393,7 +393,7 @@ class RecaptchaField_HTTPClient extends Object {
 		curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
 		curl_setopt($ch, CURLOPT_USERAGENT, 'reCAPTCHA/PHP');
 		// we need application/x-www-form-urlencoded
-		curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($postVars)); 
+		curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($postVars, "", "&")); 
 		$response = curl_exec($ch);
 
 		if(class_exists('SS_HTTPResponse')) {


### PR DESCRIPTION
The plugin broke because &amp; was submitted in the key instead of &. Fixed it by recoding you post function.
