### PR TITLE
FIX Ajax API doesn't load in correct order

### DIFF
--- a/code/RecaptchaField.php
+++ b/code/RecaptchaField.php
@@ -182,16 +182,14 @@ class RecaptchaField extends SpamProtectorField {
 			$ajaxURL = ($this->useSSL) ? 'https://' : 'http://';
 			$ajaxURL .= self::$recaptcha_ajax_url;
 			Requirements::javascript($ajaxURL);
-			$html .= '
-				<script type="text/javascript">
+			Requirements::customScript('
 					//<![CDATA[
 					Recaptcha.create("' . self::$public_api_key . '",
 					"' . $this->getName() . '", {
 					   callback: Recaptcha.focus_response_field
 					});
 				//]]>
-				</script>
-			';
+			');
 		} else {
 			if(!empty($this->jsOptions) && isset($this->jsOptions['theme']) && $this->jsOptions['theme'] === 'custom'){
 				$html .= $this->renderWith("CustomRecaptchaField");


### PR DESCRIPTION
At the moment, the Recaptcha JS file is loaded at the end of the <body> using requirements, but the inline script that depends on it is injected to the template immediately.

This injects the inline script after the external file so that the dependence is ready

This looks like a problem in all the branches so should be merged into all of them
