### PR TITLE
Read out the entire request instead of postVars()

### DIFF
--- a/code/RecaptchaField.php
+++ b/code/RecaptchaField.php
@@ -158,14 +158,14 @@ class RecaptchaField extends FormField
      */
     public function validate($validator)
     {
-        /** @var array $request */
+        /** @var array $postVars */
         if(SapphireTest::is_running_test()) {
-            $request = $_REQUEST;
+            $postVars = $_REQUEST;
         } else {
-            $request = Controller::curr()->getRequest();
+            $postVars = Controller::curr()->getRequest()->postVars();
         }
         // don't bother querying the recaptcha-service if fields were empty
-        if (!array_key_exists('g-recaptcha-response', $request) || empty($request['g-recaptcha-response'])) {
+        if (!array_key_exists('g-recaptcha-response', $postVars) || empty($postVars['g-recaptcha-response'])) {
             $validator->validationError(
                 $this->name,
                 _t(
@@ -181,7 +181,7 @@ class RecaptchaField extends FormField
             return false;
         }
 
-        $response = $this->recaptchaHTTPPost($_REQUEST['g-recaptcha-response']);
+        $response = $this->recaptchaHTTPPost($postVars['g-recaptcha-response']);
 
         if (!$response) {
             $validator->validationError(


### PR DESCRIPTION
Due to the tests not failing, I did not spot this.