### PR TITLE
FIX: ArrayAccess does not support array_key_exists.

### DIFF
--- a/code/RecaptchaField.php
+++ b/code/RecaptchaField.php
@@ -164,8 +164,9 @@ class RecaptchaField extends FormField
         } else {
             $request = Controller::curr()->getRequest();
         }
-        // don't bother querying the recaptcha-service if fields were empty
-        if (!array_key_exists('g-recaptcha-response', $request) || empty($request['g-recaptcha-response'])) {
+
+        // If the field is empty don't bother querying the recaptcha-service
+        if (!isset($request['g-recaptcha-response']) || empty($request['g-recaptcha-response'])) {
             $validator->validationError(
                 $this->name,
                 _t(


### PR DESCRIPTION
Unfortunately `array_key_exists()` doesn't call `ArrayAccess::offsetExists()`. Using `isset()` seemed like a reasonable substitution in this case. I should also add that without this patch `RecaptchaField::validate()` always considers the field empty and so validation always fails.