### PR TITLE
Removed reference to Invisible reCaptcha option, as it isn't

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,6 @@
 Provides a FormField which allows form to validate for non-bot submissions
 using Google's [reCAPTCHA v2](https://developers.google.com/recaptcha/docs/display) service.
 
-In order to use Google's new [Invisible reCAPTCHA](https://developers.google.com/recaptcha/docs/invisible) service,
-please use the [undefinedoffset/silverstripe-nocaptcha](https://github.com/UndefinedOffset/silverstripe-nocaptcha) module.
-
 ## Requirements
 
  * SilverStripe Framework 4.0 or newer


### PR DESCRIPTION
UndefinedOffset's plugin implements reCaptcha v2 (aka NoCaptcha), same as this one. So probably no reason to mention it in this readme?